### PR TITLE
add view namespace to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ protected function setupUpdateOperation()
 	CRUD::addField([
 		'name' => 'pictures',
 		'type' => 'medialibrary-dropzone',
+                'view_namespace' => 'medialibrary-dropzone::fields',
 		'url' => "/mymodel/{$this->crud->getCurrentEntry()->id}/picture"
 	]);
 }


### PR DESCRIPTION
Fixes #2. This alone made the field show up, for me:
![Screenshot 2020-08-14 at 11 15 40](https://user-images.githubusercontent.com/1032474/90264746-34a6f000-de5a-11ea-9fc4-f8e738c5c3b6.png)
