### PR TITLE
add spatie/laravel-medialibrary as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "homepage": "https://github.com/digitallyhappy/toggle-field-for-backpack",
     "keywords": ["Laravel", "Backpack", "Backpack for Laravel", "Addon", "Admin Panel", "MediaLibrary","Dropzone"],
     "require": {
-        "backpack/crud": "^4.1.0"
+        "backpack/crud": "^4.1.0",
+        "spatie/laravel-medialibrary": "^8.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
To make sure that `spatie/laravel-medialibrary` is installed, and the version installed is supported, I think it's best to have it as a requirement in composer.json.

Bonus: when installing this addon, it's one less command, if they have the addon installed, they already have `spatie/laravel-medialibrary` installed too.